### PR TITLE
Also load sf when geobr is loaded

### DIFF
--- a/R/geobr.R
+++ b/R/geobr.R
@@ -25,3 +25,7 @@ if(getRversion() >= "2.15.1")  utils::globalVariables(c('brazil_2010',
                                                         'code_region',
                                                         'name_region',
                                                         'group_by'))
+
+.onLoad <- function(lib, pkg) {
+  require(sf)
+}


### PR DESCRIPTION
There is a minor bug when one executes the code below without loading sf explicitly:

```R
require(geobr)
d <- read_biomes(year = 2004)
plot(d)
```

```
Error in data.matrix(x) : 
  (list) object cannot be coerced to type 'double'
In addition: Warning messages:
1: In data.matrix(x) : NAs introduced by coercion
2: In data.matrix(x) : NAs introduced by coercion```
```

This pull request also loads sf while loading geobr to avoid such error.