### PR TITLE
Implements first version of metadata download (closes #94)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ python-package/notebooks/
 # VSCODE
 *.vscode
 /r-package/.Rhistory
+__pycache__
+.pytest_cache
+

--- a/python-package/geobr/utils.py
+++ b/python-package/geobr/utils.py
@@ -1,20 +1,37 @@
 import requests
+import pandas as pd
+import tempfile
 
-def download_metadata():
+def download_metadata(
+    url='http://www.ipea.gov.br/geobr/metadata/metadata_gpkg.csv'):
+    """Support function to download metadata internally used in geobr.
 
-    metadata_url = 'http://www.ipea.gov.br/geobr/metadata/metadata.rds'
+    Parameters
+    ----------
+    url : str, optional
+        Metadata url, by default 'http://www.ipea.gov.br/geobr/metadata/metadata_gpkg.csv'
+    
+    Returns
+    -------
+    pd.DataFrame
+        Table with all metadata of geopackages
+    
+    Raises
+    ------
+    Exception
+        Leads user to Github issue page if metadata url is not found
 
-    metadata = requests.get(metadata_url)
+    Examples
+    --------
+    >>> metadata = download_metadata()
+    >>> metadata.head(1)
+                  geo  year code                                      download_path      code_abrev
+    0  amazonia_legal  2012   am  http://www.ipea.gov.br/geobr/data_gpkg/amazoni...  amazonia_legal
+    """
 
-    # return pd.DataFrame(metadata)
+    try:
+        return pd.read_csv(url)
 
-    return 'metadata'
-
-def get_metadata(geo):
-
-    metadata = download_metadata()
-
-    # select metadata based on geo
-    # ...
-
-    return 'metadata_selected_geo'
+    except HTTPError:
+        raise Exception('Metadata file not found. \
+            Please report to https://github.com/ipeaGIT/geobr/issues')

--- a/python-package/geobr/utils.py
+++ b/python-package/geobr/utils.py
@@ -1,10 +1,14 @@
 import requests
 import pandas as pd
 import tempfile
+from functools import lru_cache
 
+@lru_cache(maxsize=124)
 def download_metadata(
     url='http://www.ipea.gov.br/geobr/metadata/metadata_gpkg.csv'):
     """Support function to download metadata internally used in geobr.
+
+    It caches the metadata file to avoid reloading it in the same session.
 
     Parameters
     ----------

--- a/python-package/tests/test_utils.py
+++ b/python-package/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
-import pandas as pd
 import geobr
+from time import time
 
 @pytest.fixture
 def metadata_file():
@@ -19,3 +19,10 @@ def test_download_metadata(metadata_file):
 
     # Check if it has content
     assert len(metadata_file) > 0
+
+def test_download_metadata_cache():
+    
+    # Check if cache works
+    start_time = time()
+    geobr.utils.download_metadata()
+    assert time() - start_time < 1

--- a/python-package/tests/test_utils.py
+++ b/python-package/tests/test_utils.py
@@ -1,0 +1,21 @@
+import pytest
+import pandas as pd
+import geobr
+
+@pytest.fixture
+def metadata_file():
+    return geobr.utils.download_metadata()
+
+def test_utils(metadata_file):
+
+    # Check if it fails if it doesn't find a file
+    with pytest.raises(Exception):
+        geobr.utils.download_metadata(
+            url='http://www.ipea.gov.br/geobr/metadata/met')
+
+    # Check if columns are the same
+    assert (['geo', 'year', 'code', 'download_path', 'code_abrev'] == \
+            metadata_file.columns).all()
+
+    # Check if it has content
+    assert len(metadata_file) > 0

--- a/python-package/tests/test_utils.py
+++ b/python-package/tests/test_utils.py
@@ -6,7 +6,7 @@ import geobr
 def metadata_file():
     return geobr.utils.download_metadata()
 
-def test_utils(metadata_file):
+def test_download_metadata(metadata_file):
 
     # Check if it fails if it doesn't find a file
     with pytest.raises(Exception):


### PR DESCRIPTION
Python implementation of metadata download.

- It loads the file into a pandas dataframe.
- It raises an error that leads the user to the issue page of this project if the metadata link is not found.
- I added tests.
- The R function saves it into a tempfile in order to save time. In python, the time to download this file and load to a dataframe is about 2 seconds. Whereas, just to locally load is 100 ms. I didn't implement it yet because the native `tempfile` package from python does not behave like the R `tempdir` implementation. I am going to research a little bit more about how to do it properly. But, if you feel that is not that crucial, we can keep going with the other functions and implement this functionality in a future version.