### PR TITLE
add geopandas to dependencies #bugfix

### DIFF
--- a/python-package/requirements.txt
+++ b/python-package/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.20.0
 pandas==1.0.1
+geopandas==0.7.0


### PR DESCRIPTION
We are [already using geopandas](https://github.com/ipeaGIT/geobr/blob/master/python-package/geobr/utils.py#L4), but this dependency is not present in the `requirements.txt` file. This PR fixes that.