### PR TITLE
Fixing typo crul -> curl

### DIFF
--- a/r-package/DESCRIPTION
+++ b/r-package/DESCRIPTION
@@ -31,7 +31,7 @@ Depends:
     R (>= 3.5.0)
 Suggests:
     covr,
-    crul,
+    curl,
     dplyr (>= 0.8-3),
     ggplot2 (>= 3.3.1),
     knitr,

--- a/r-package/R/utils.R
+++ b/r-package/R/utils.R
@@ -274,7 +274,7 @@ check_connection <- function(file_url = 'https://www.ipea.gov.br/geobr/metadata/
   }
 
   # test server connection
-  if (! crul::ok(file_url, verbose=FALSE) ) {
+  if (! curl::ok(file_url, verbose=FALSE) ) {
     message("Problem connecting to data server. Please try geobr again in a few minutes.")
     return(invisible(NULL))
   }


### PR DESCRIPTION
Hello, I noticed a typo in the latest version of the package. The curl package was typed incorrectly in two files, as 'crul'.

Fix the change in the files that had the error.