### PR TITLE
Fixes for readr 2.0.0

### DIFF
--- a/r-package/R/list_geobr.R
+++ b/r-package/R/list_geobr.R
@@ -35,11 +35,11 @@ table_end <- grep("Other functions", readme) -1
 table_strig <- readme[table_start:table_end]
 
 # read table as a data.frame
-suppressWarnings({ df <- readr::read_delim(table_strig, delim = '|', trim_ws = T) })
+suppressWarnings({ df <- readr::read_delim(I(table_strig), delim = '|', trim_ws = T) })
 
 # clean colunms
-  df$X1 <- NULL
-  df$X6 <- NULL
+  df[[1]] <- NULL
+  df[[5]] <- NULL
 
 # remove 1st row with "-----"
 df <- df[-1,]


### PR DESCRIPTION
readr 2.0.0 requires literal data to be marked with `I()` when passed to
the reading function. Also the way that name repair happens has changed,
so X1 and X6 are no longer the correct names.

Removing the columns by position rather than name solves this second
issue.