### PR TITLE
refactor function cep_to_state

### DIFF
--- a/r-package/R/cep_to_state.R
+++ b/r-package/R/cep_to_state.R
@@ -21,43 +21,45 @@ cep_to_state <- function(cep){
   # https://help.commerceplus.com.br/hc/pt-br/articles/115008224967-Faixas-de-CEP-por-Estado
   # https://mundoeducacao.bol.uol.com.br/curiosidades/o-que-significam-os-numeros-cep.htm
 
-  cep <- gsub("-", "", cep)
+  ceps <- list(
+    list(state = "AC", range = c(69900000L, 69999999L)),
+    list(state = "AL", range = c(57000000L, 57999999L)),
+    list(state = "AM", range = c(69000000L, 69299999L)),
+    list(state = "AM", range = c(69400000L, 69899999L)),
+    list(state = "AP", range = c(68900000L, 68999999L)),
+    list(state = "BA", range = c(40000000L, 48999999L)),
+    list(state = "CE", range = c(60000000L, 63999999L)),
+    list(state = "DF", range = c(70000000L, 72799999L)),
+    list(state = "DF", range = c(73000000L, 73699999L)),
+    list(state = "ES", range = c(29000000L,	29999999L)),
+    list(state = "GO", range = c(72800000L, 72999999L)),
+    list(state = "GO", range = c(73700000L, 76799999L)),
+    list(state = "MA", range = c(65000000L, 65999999L)),
+    list(state = "MG", range = c(65999999L, 39999999L)),
+    list(state = "MS", range = c(79000000L, 79999999L)),
+    list(state = "MT", range = c(78000000L, 78899999L)),
+    list(state = "PA", range = c(66000000L, 68899999L)),
+    list(state = "PB", range = c(58000000L, 58999999L)),
+    list(state = "PE", range = c(50000000L, 56999999L)),
+    list(state = "PI", range = c(64000000L, 64999999L)),
+    list(state = "PR", range = c(80000000L, 87999999L)),
+    list(state = "RJ", range = c(20000000L, 28999999L)),
+    list(state = "RN", range = c(59000000L, 59999999L)),
+    list(state = "RO", range = c(76800000L, 76999999L)),
+    list(state = "RR", range = c(69300000L, 69399999L)),
+    list(state = "RS", range = c(90000000L, 99999999L)),
+    list(state = "SC", range = c(88000000L, 89999999L)),
+    list(state = "SE", range = c(49000000L, 49999999L)),
+    list(state = "SP", range = c(01000000L, 19999999L)),
+    list(state = "TO", range = c(77000000L, 77999999L))
+  )
 
-  suppressWarnings({ firstdigits1 <- as.numeric(substr(cep, 1,1)) })
-  suppressWarnings({ firstdigits2 <- as.numeric(substr(cep, 1,2)) })
-  suppressWarnings({ firstdigits3 <- as.numeric(substr(cep, 1,3)) })
+  cep <- as.numeric(gsub("-", "", cep))
 
-  if(is.na(firstdigits3)){stop("'cep' input must have numerical digits.")}
-
-  ifelse( firstdigits1 == 0,   'SP',   # Sao Paulo
-  ifelse( firstdigits1 == 1,   'SP',   # Sao Paulo
-  ifelse( firstdigits1 == 3,   'MG',   # Minas Gerais
-  ifelse( firstdigits1 == 9,   'RS',   # Rio Grande do Sul
-  ifelse( firstdigits2 ==29,   'Es',   # Espirito Santo
-  ifelse( firstdigits2 ==49,   'SE',   # Sergipe
-  ifelse( firstdigits2 ==64,   'PI',   # Piaui
-  ifelse( firstdigits2 ==65,   'MA',   # Maranhao
-  ifelse( firstdigits3 ==689,  'AP',   # Amapa
-  ifelse( firstdigits3 ==699,  'AC',   # Acre
-  ifelse( firstdigits3 ==693,  'RR',   # Roraima
-  ifelse( firstdigits2 ==77,   'TO',   # Tocantins
-  ifelse( firstdigits2 ==79,   'MS',   # Mato Grosso do Sul
-  ifelse( firstdigits2 ==78,   'MT',   # Mato Grosso
-  ifelse( firstdigits2 ==57,   'AL',   # Alagoas
-  ifelse( firstdigits2 ==58,   'PB',   # Paraiba
-  ifelse( firstdigits2 ==59,   'RN',   # Rio Grande do Norte
-  ifelse( firstdigits2 >20  & firstdigits2 <28,  'RJ', # Rio de Janeiro
-  ifelse( firstdigits2 >40  & firstdigits2 <48,  'BA', # Bahia
-  ifelse( firstdigits2 >80  & firstdigits2 <87,  'PR', # Parana
-  ifelse( firstdigits2 >88  & firstdigits2 <89,  'SC', # Santa Catarina
-  ifelse( firstdigits2 >50  & firstdigits2 <56,  'PE', # Pernambuco
-  ifelse( firstdigits2 >60  & firstdigits2 <63,  'CE', # ceara
-  ifelse( firstdigits2 >66  & firstdigits2 <68,  'PA', # Para
-  ifelse( firstdigits3 >690 & firstdigits3 <692, 'AM', # Amazonas
-  ifelse( firstdigits3 >694 & firstdigits3 <698, 'AM', # Amazonas
-  ifelse( firstdigits3 >700 & firstdigits3 <727, 'DF', # Distrito Federal
-  ifelse( firstdigits3 >730 & firstdigits3 <736, 'DF', # Distrito Federal
-  ifelse( firstdigits3 >768 & firstdigits3 <769, 'RO', # Rondonia
-  ifelse( firstdigits3 >728 & firstdigits3 <729, 'GO', # Goias
-  ifelse( firstdigits3 >737 & firstdigits3 <767, 'GO', 'ERROR')))))))))))))))))))))))))))))))
+  for (value in ceps) {
+    if (cep >= value$range[1] && cep <= value$range[2]) {
+      return(value$state)
+    }
+  }
+  stop("CEP not found")
 }

--- a/r-package/R/cep_to_state.R
+++ b/r-package/R/cep_to_state.R
@@ -21,6 +21,16 @@ cep_to_state <- function(cep){
   # https://help.commerceplus.com.br/hc/pt-br/articles/115008224967-Faixas-de-CEP-por-Estado
   # https://mundoeducacao.bol.uol.com.br/curiosidades/o-que-significam-os-numeros-cep.htm
 
+  # not null
+  if (!is.null(cep)) {stop("Error: 'cep' cannot be NULL.") }
+
+  # checks
+  cep <- as.numeric(gsub("-", "", cep))
+  if (!length(cep)==8) {stop("'cep' must have numeric 8 digits." }
+
+  suppressWarnings({ cep <- as.numeric(cep) })
+  if (is.na(cep)) {stop("'cep' input must have numerical digits.")}
+
   ceps <- list(
     list(state = "AC", range = c(69900000L, 69999999L)),
     list(state = "AL", range = c(57000000L, 57999999L)),
@@ -53,8 +63,6 @@ cep_to_state <- function(cep){
     list(state = "SP", range = c(01000000L, 19999999L)),
     list(state = "TO", range = c(77000000L, 77999999L))
   )
-
-  cep <- as.numeric(gsub("-", "", cep))
 
   for (value in ceps) {
     if (cep >= value$range[1] && cep <= value$range[2]) {


### PR DESCRIPTION
This PR refactor `cep_to_state` function. 

- Remove nesteds `ifelse`, uses a structure that is easier to maintain
- Remove unnecessary vectorization (`ifelse` and `&`)
- Stricter verification, now `cep_to_state("7900000000000000")` raise a error. Currently return `"MS"`