### PR TITLE
Fix column typo abrev --> abbrev ( for lookup_muni )

### DIFF
--- a/r-package/prep_data/prep_lookup.R
+++ b/r-package/prep_data/prep_lookup.R
@@ -151,27 +151,27 @@ lookup_end_format <- lookup_end %>%
   mutate(name_muni_format = trimws(name_muni_format, "both"))
 
 
-#### 3. Bring UF abrev -----------------
+#### 3. Bring UF abbrev -----------------
 
 lookup_state <- data.frame(name_uf = c("Acre", "Alagoas", "Amapá", "Amazonas", "Bahia", "Ceará", "Distrito Federal", "Espírito Santo",
                                        "Goiás", "Maranhão", "Mato Grosso", "Mato Grosso do Sul", "Minas Gerais",
                                        "Pará", "Paraíba", "Paraná", "Pernambuco", "Piauí", "Rio de Janeiro",
                                        "Rio Grande do Norte", "Rio Grande do Sul", "Rondônia", "Roraima",
                                        "Santa Catarina", "São Paulo", "Sergipe", "Tocantins"),
-                           abrev_state = c("AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", 
+                           abbrev_state = c("AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", 
                                            "GO", "MA", "MT", "MS", "MG",
                                            "PA", "PB", "PR", "PE", "PI", "RJ", 
                                            "RN", "RS", "RO", "RR",
                                            "SC", "SP", "SE", "TO"))
 
-# bring abrev state
+# bring abbrev state
 lookup_end_format <- lookup_end_format %>%
   left_join(lookup_state, by = c("name_state" = "name_uf"))
 
 # organize columns
 lookup_end_format <- lookup_end_format %>%
   select(code_muni, name_muni,
-         code_state, name_state, abrev_state,
+         code_state, name_state, abbrev_state,
          code_micro, name_micro,
          code_meso, name_meso,
          code_immediate, name_immediate,


### PR DESCRIPTION
As described in #282, 

`lookup_muni` has a column named `abrev_state` (single B), while other databases use abbrev_state (double B).

A lookup table should make it easier to connect different tables, and therefore their columns should be standardized.