### PR TITLE
Fix table formatting and typing errors on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ More examples [here](https://github.com/ipeaGIT/geobr/tree/master/python-package
 |`read_health_region` | Health regions and macro regions | 1991, 1994, 1997, 2001, 2005, 2013 | DataSUS |
 |`read_neighborhood` | Neighborhood limits |  2010 | IBGE |
 |`read_schools` | Schools |  2020, 2023 | INEP |
-|`read_comparable_areas` | Historically comparable municipalities, aka Areas minimas comparaveis (AMCs) |  1872,1900,1911,1920,1933,1940,1950,1960,1970,1980,1991,2000,2010 | IBGE |
+|`read_comparable_areas` | Historically comparable municipalities, aka Áreas mínimas comparáveis (AMCs) |  1872, 1900, 1911, 1920, 1933, 1940, 1950, 1960, 1970, 1980, 1991, 2000, 2010 | IBGE |
 |`read_urban_concentrations` | Urban concentration areas (concentrações urbanas) | 2015 | IBGE | 
-|`read_pop_arrangements` | Population arrangements (arranjos populacioanis) | 2015 | IBGE | 
+|`read_pop_arrangements` | Population arrangements (arranjos populacionais) | 2015 | IBGE | 
 
 
 


### PR DESCRIPTION
Fix #351 by formatting non-spaced line at markdown table and also fix typos. 