### PR TITLE
feat: Add download_all_layers function

### DIFF
--- a/python-package/geobr/download_all_layers.py
+++ b/python-package/geobr/download_all_layers.py
@@ -1,0 +1,97 @@
+import os
+from geobr import (
+    read_country, read_region, read_state, read_meso_region,
+    read_micro_region, read_intermediate_region, read_immediate_region,
+    read_municipality, read_municipal_seat, read_weighting_area,
+    read_census_tract, read_statistical_grid, read_metro_area,
+    read_urban_area, read_amazon, read_biomes, read_conservation_units,
+    read_disaster_risk_area, read_indigenous_land, read_semiarid,
+    read_health_facilities, read_health_region, read_neighborhood,
+    read_schools, read_comparable_areas, read_urban_concentrations,
+    read_pop_arrangements
+)
+
+def download_all_layers(output_folder="geobr_layers", driver="GeoJSON"):
+    """
+    Downloads all available geographic layers from geobr using their most recent year
+    and saves them to the specified output folder.
+    
+    Parameters
+    ----------
+    output_folder : str, optional
+        Folder where the layers will be saved, by default "geobr_layers"
+    driver : str, optional
+        The OGR format driver to use for saving the files. Options are:
+        - 'GeoJSON' (default)
+        - 'GPKG' (GeoPackage)
+        
+    Raises
+    ------
+    ValueError
+        If the specified driver is not supported
+    """
+    # Validate driver
+    valid_drivers = ["GEOJSON", "GPKG"]
+    if driver.upper() not in valid_drivers:
+        raise ValueError(f"Invalid driver: {driver}. Must be one of: {', '.join(valid_drivers)}")
+    # Create output folder if it doesn't exist
+    os.makedirs(output_folder, exist_ok=True)
+    
+    # Dictionary with function names
+    layers = {
+        'country': read_country,
+        'region': read_region,
+        'state': read_state,
+        'meso_region': read_meso_region,
+        'micro_region': read_micro_region,
+        'intermediate_region': read_intermediate_region,
+        'immediate_region': read_immediate_region,
+        'municipality': read_municipality,
+        'municipal_seat': read_municipal_seat,
+        'weighting_area': read_weighting_area,
+        'census_tract': read_census_tract,
+        'statistical_grid': read_statistical_grid,
+        'metro_area': read_metro_area,
+        'urban_area': read_urban_area,
+        'amazon': read_amazon,
+        'biomes': read_biomes,
+        'conservation_units': read_conservation_units,
+        'disaster_risk_area': read_disaster_risk_area,
+        'indigenous_land': read_indigenous_land,
+        'semiarid': read_semiarid,
+        'health_facilities': read_health_facilities,
+        'health_region': read_health_region,
+        'neighborhood': read_neighborhood,
+        'schools': read_schools,
+        'comparable_areas': read_comparable_areas,
+        'urban_concentrations': read_urban_concentrations,
+        'pop_arrangements': read_pop_arrangements
+    }
+    
+    # Download each layer
+    for name, func in layers.items():
+        print(f"Downloading {name}...")
+        try:
+            # Download the layer using default year
+            gdf = func()
+            
+            # Set file extension based on driver
+            if driver.upper() == "GEOJSON":
+                ext = ".geojson"
+            elif driver.upper() == "GPKG":
+                ext = ".gpkg"
+            else:
+                ext = ".geojson"  # default to geojson
+                
+            # Save to file
+            output_file = os.path.join(output_folder, f"{name}{ext}")
+            gdf.to_file(output_file, driver=driver)
+            print(f"✓ Successfully saved {name} to {output_file}")
+            
+        except Exception as e:
+            print(f"✗ Error downloading {name}: {str(e)}")
+            continue
+
+if __name__ == "__main__":
+    # Download all layers to a folder called 'geobr_layers'
+    download_all_layers()

--- a/python-package/tests/test_download_all_layers.py
+++ b/python-package/tests/test_download_all_layers.py
@@ -1,0 +1,55 @@
+import os
+import shutil
+import geopandas as gpd
+import pytest
+from geobr.download_all_layers import download_all_layers
+
+def test_download_all_layers():
+    # Create a temporary test directory
+    test_dir = "test_geobr_layers"
+    
+    try:
+        # Test with default parameters (GeoJSON driver)
+        download_all_layers(output_folder=test_dir)
+        
+        # Check if directory was created
+        assert os.path.exists(test_dir)
+        
+        # Check if at least some key files were created with correct format
+        key_layers = ['country', 'state', 'municipality']
+        for layer in key_layers:
+            file_path = os.path.join(test_dir, f"{layer}.geojson")
+            assert os.path.exists(file_path)
+            
+            # Try reading the file to ensure it's valid
+            gdf = gpd.read_file(file_path)
+            assert isinstance(gdf, gpd.GeoDataFrame)
+            assert not gdf.empty
+        
+        # Test with GPKG driver
+        gpkg_dir = "test_geobr_layers_gpkg"
+        download_all_layers(output_folder=gpkg_dir, driver="GPKG")
+        
+        # Check if directory was created
+        assert os.path.exists(gpkg_dir)
+        
+        # Check if files were created with correct format
+        for layer in key_layers:
+            file_path = os.path.join(gpkg_dir, f"{layer}.gpkg")
+            assert os.path.exists(file_path)
+            
+            # Try reading the file to ensure it's valid
+            gdf = gpd.read_file(file_path)
+            assert isinstance(gdf, gpd.GeoDataFrame)
+            assert not gdf.empty
+            
+    finally:
+        # Clean up test directories
+        if os.path.exists(test_dir):
+            shutil.rmtree(test_dir)
+        if os.path.exists(gpkg_dir):
+            shutil.rmtree(gpkg_dir)
+
+def test_download_all_layers_invalid_driver():
+    with pytest.raises(ValueError, match="Invalid driver"):
+        download_all_layers(driver="INVALID_DRIVER")


### PR DESCRIPTION
Add download_all_layers function

This PR adds a new function that allows users to download all available geobr layers at once.

Features
- New `download_all_layers` function that downloads all available layers using their default years
- Support for two output formats:
  - GeoJSON (default)
  - GPKG (GeoPackage)
- Configurable output folder (defaults to 'geobr_layers')
- Proper error handling and driver validation
- Comprehensive test coverage

Example Usage
```python
from geobr import download_all_layers

Download all layers in GeoJSON format (default)
download_all_layers()

Download all layers in GeoPackage format
download_all_layers(driver="GPKG")

Download to a custom folder
download_all_layers(output_folder="my_layers")