### PR TITLE
Clarify read_neighborhood code_muni errors

### DIFF
--- a/r-package/R/read_neighborhood.R
+++ b/r-package/R/read_neighborhood.R
@@ -58,7 +58,12 @@ read_neighborhood <- function(year,
   if (is.null(temp_arrw)) { return(invisible(NULL)) }
 
   # FILTER
-  temp_arrw <- filter_arrw(temp_arrw, code = code_muni)
+  temp_arrw <- filter_arrw(
+    temp_arrw,
+    code = code_muni,
+    code_arg = "code_muni",
+    empty_msg = "No neighborhood data available for the requested `code_muni` and year."
+  )
 
   # convert to sf
   temp <- convert_output(temp_arrw, output)

--- a/r-package/R/utils.R
+++ b/r-package/R/utils.R
@@ -205,7 +205,9 @@ numbers_only <- function(x){ !grepl("\\D", x) } # nocov
 #'
 #' @keywords internal
 filter_arrw <- function(temp_arrw = parent.frame()$temp_arrw,
-                        code){ # nocov start
+                        code,
+                        code_arg = "code_",
+                        empty_msg = NULL){ # nocov start
 
   # all states
   if (any(code == 'all')) {return(temp_arrw)}
@@ -237,7 +239,7 @@ filter_arrw <- function(temp_arrw = parent.frame()$temp_arrw,
 
   # check
   if (is.null(filter_col)) {
-    cli::cli_abort("Invalid value to argument `code_`.")
+    cli::cli_abort("Invalid value to argument `{code_arg}`.")
     }
 
   # filter
@@ -249,7 +251,11 @@ filter_arrw <- function(temp_arrw = parent.frame()$temp_arrw,
   # if  (nrow(temp_arrw) == 0){
   nrows <- dplyr::count(temp_arrw) |> dplyr::collect()
   if  (nrows$n == 0){
-    cli::cli_abort("Invalid value to argument `code_`.")
+    if (is.null(empty_msg)) {
+      empty_msg <- "Invalid value to argument `{code_arg}`."
+    }
+
+    cli::cli_abort(empty_msg)
   }
 
   return(temp_arrw)

--- a/r-package/man/read_neighborhood.Rd
+++ b/r-package/man/read_neighborhood.Rd
@@ -15,8 +15,7 @@ read_neighborhood(
 )
 }
 \arguments{
-\item{year}{Numeric. Year of the data in YYYY format. It defaults to \code{NULL}
-and reads the data from the latest year available.}
+\item{year}{Numeric. Year of the data in YYYY format.}
 
 \item{code_muni}{The 7-digit code of a municipality. If \code{code_muni = "all"}
 (Default), the function downloads all the data available in the

--- a/r-package/man/roxygen/templates/year.R
+++ b/r-package/man/roxygen/templates/year.R
@@ -1,2 +1,1 @@
-#' @param year Numeric. Year of the data in YYYY format. It defaults to `NULL`
-#'        and reads the data from the latest year available.
+#' @param year Numeric. Year of the data in YYYY format.


### PR DESCRIPTION
Closes #424.

Summary:
- lets filter_arrw receive the public argument name used by callers
- makes read_neighborhood report when no neighborhood data is available for the requested code_muni and year
- updates the year documentation text that still mentioned NULL as the default

Validation:
- reviewed the focused diff in r-package/R/utils.R and r-package/R/read_neighborhood.R
- checked the updated documentation text in r-package/man/roxygen/templates/year.R and r-package/man/read_neighborhood.Rd
- Rscript is not available in this Windows/WSL environment, so executable R checks could not be run locally