### PR TITLE
Fix list_geobr README parsing

### DIFF
--- a/python-package/geobr/list_geobr.py
+++ b/python-package/geobr/list_geobr.py
@@ -1,8 +1,39 @@
 from requests import get
+from requests.exceptions import RequestException
 import pandas as pd
-from io import StringIO
-from urllib.error import HTTPError
-import re
+
+README_URL = "https://raw.githubusercontent.com/ipeaGIT/geobr/master/README.md"
+DATASETS_TABLE_HEADER = "| Function | Geographies available | Source | Years available |"
+
+
+def _split_markdown_row(row):
+    return [cell.strip() for cell in row.strip().strip("|").split("|")]
+
+
+def _parse_available_datasets(readme_data):
+    lines = readme_data.splitlines()
+
+    for index, line in enumerate(lines):
+        if line.strip() != DATASETS_TABLE_HEADER:
+            continue
+
+        columns = _split_markdown_row(line)
+        rows = []
+
+        for row in lines[index + 2 :]:
+            if not row.strip().startswith("|"):
+                break
+
+            values = _split_markdown_row(row)
+
+            if len(values) == len(columns):
+                rows.append(dict(zip(columns, values)))
+
+        if rows:
+            return pd.DataFrame(rows)
+
+    raise ValueError("Could not find geobr datasets table in README.md")
+
 
 def list_geobr():
     """Prints available functions, according to latest README.md file
@@ -18,19 +49,15 @@ def list_geobr():
     """
 
     try:
-        html_data = get("https://github.com/ipeaGIT/geobr/blob/v1.9.1/README.md").text
-        find_emoji = html_data.index("👉")
-        html_data =  html_data[find_emoji:]
-        escaped_data = html_data.replace("\\u003c", "<").replace("\\u003e", ">")
-        tables = re.findall("<table>(.+?)</table>", escaped_data)
-        available_datasets = "<table>" + tables[0].replace("\\n", "") + "</table>"
-        df = pd.DataFrame(pd.read_html(StringIO(available_datasets))[0])
-
-    except HTTPError:
+        response = get(README_URL, timeout=10)
+        response.raise_for_status()
+        df = _parse_available_datasets(response.text)
+    except (RequestException, ValueError):
         print(
-            "Geobr url functions list is broken"
+            "Geobr url functions list is broken. "
             'Please report an issue at "https://github.com/ipeaGIT/geobr/issues"'
         )
+        return
 
     for i in range(len(df)):
         for each in df.columns:

--- a/python-package/tests/test_list_geobr.py
+++ b/python-package/tests/test_list_geobr.py
@@ -1,6 +1,7 @@
 import pytest
 
 from geobr import list_geobr
+from geobr.list_geobr import _parse_available_datasets
 
 
 @pytest.mark.network
@@ -8,3 +9,27 @@ def test_list_geobr(capsys):
     list_geobr()
     captured = capsys.readouterr()
     assert len(captured.out) > 200
+
+
+def test_parse_available_datasets_from_markdown_table():
+    readme = """
+# geobr
+
+| Function | Geographies available | Source | Years available |
+|:---|:---|:---|:---|
+| read_country | Country | IBGE | 2020, 2025 |
+| read_state | States | IBGE | 2022, 2025 |
+
+point_right: All datasets use SIRGAS2000.
+"""
+
+    datasets = _parse_available_datasets(readme)
+
+    assert list(datasets.columns) == [
+        "Function",
+        "Geographies available",
+        "Source",
+        "Years available",
+    ]
+    assert datasets.loc[0, "Function"] == "read_country"
+    assert datasets.loc[1, "Years available"] == "2022, 2025"


### PR DESCRIPTION
## Summary
This updates the Python list_geobr() implementation to parse the datasets table from the raw README markdown instead of depending on GitHub-rendered HTML and an emoji anchor.

The change makes the function resilient to the substring not found failure reported when the expected emoji is absent from the fetched HTML.

Closes #432

## Validation
- python -m py_compile geobr/list_geobr.py tests/test_list_geobr.py
- git diff --check

I could not run pytest in this Windows environment because uv, pytest, and the package runtime dependencies are not installed.